### PR TITLE
Cambiar \spacing{...} por \setstretch{...}

### DIFF
--- a/Template_Report/Tex_Files/packages.tex
+++ b/Template_Report/Tex_Files/packages.tex
@@ -35,7 +35,7 @@
 
 % ESPACIADO
 \usepackage{setspace}
-\spacing{1.2}
+\setstretch{1.2}
 \let\ph\mlplaceholder % shorter macro
 
 

--- a/Template_Thesis/Tex_Files/packages.tex
+++ b/Template_Thesis/Tex_Files/packages.tex
@@ -35,7 +35,7 @@
 
 % ESPACIADO
 \usepackage{setspace}
-\spacing{1.2}
+\setstretch{1.2}
 \let\ph\mlplaceholder % shorter macro
 
 


### PR DESCRIPTION
LaTeX 2024 arroja varios errores si se usa \spacing{...} (que realmente estaba mal utilizado, es un environmnet) en lugar de \setstrech{...}, que hace exactamente lo mismo, sin ser un environmnet

Ver https://github.com/latex3/hyperref/issues/315#issuecomment-1819739882 y https://www.overleaf.com/blog/tex-live-2024-is-now-available.
